### PR TITLE
Various memory allocation improvements.

### DIFF
--- a/yacc.go
+++ b/yacc.go
@@ -719,7 +719,7 @@ outer:
 	ftable.WriteRune('\n')
 	fmt.Fprintf(ftable, "const %sEofCode = 1\n", prefix)
 	fmt.Fprintf(ftable, "const %sErrCode = 2\n", prefix)
-	fmt.Fprintf(ftable, "const %sMaxDepth = %v\n", prefix, stacksize)
+	fmt.Fprintf(ftable, "const %sInitialStackSize = %v\n", prefix, stacksize)
 
 	//
 	// copy any postfix code
@@ -3331,18 +3331,17 @@ type $$Parser interface {
 }
 
 type $$ParserImpl struct {
-	lookahead func() int
+	lval  $$SymType
+	stack [$$InitialStackSize]$$SymType
+	char  int
 }
 
 func (p *$$ParserImpl) Lookahead() int {
-	return p.lookahead()
+	return p.char
 }
 
 func $$NewParser() $$Parser {
-	p := &$$ParserImpl{
-		lookahead: func() int { return -1 },
-	}
-	return p
+	return &$$ParserImpl{}
 }
 
 const $$Flag = -1000
@@ -3470,22 +3469,20 @@ func $$Parse($$lex $$Lexer) int {
 
 func ($$rcvr *$$ParserImpl) Parse($$lex $$Lexer) int {
 	var $$n int
-	var $$lval $$SymType
 	var $$VAL $$SymType
 	var $$Dollar []$$SymType
 	_ = $$Dollar // silence set and not used
-	$$S := make([]$$SymType, $$MaxDepth)
+	$$S := $$rcvr.stack[:]
 
 	Nerrs := 0   /* number of errors */
 	Errflag := 0 /* error recovery flag */
 	$$state := 0
-	$$char := -1
-	$$token := -1 // $$char translated into internal numbering
-	$$rcvr.lookahead = func() int { return $$char }
+	$$rcvr.char = -1
+	$$token := -1 // $$rcvr.char translated into internal numbering
 	defer func() {
 		// Make sure we report no lookahead when not parsing.
 		$$state = -1
-		$$char = -1
+		$$rcvr.char = -1
 		$$token = -1
 	}()
 	$$p := -1
@@ -3517,8 +3514,8 @@ $$newstate:
 	if $$n <= $$Flag {
 		goto $$default /* simple state */
 	}
-	if $$char < 0 {
-		$$char, $$token = $$lex1($$lex, &$$lval)
+	if $$rcvr.char < 0 {
+		$$rcvr.char, $$token = $$lex1($$lex, &$$rcvr.lval)
 	}
 	$$n += $$token
 	if $$n < 0 || $$n >= $$Last {
@@ -3526,9 +3523,9 @@ $$newstate:
 	}
 	$$n = $$Act[$$n]
 	if $$Chk[$$n] == $$token { /* valid shift */
-		$$char = -1
+		$$rcvr.char = -1
 		$$token = -1
-		$$VAL = $$lval
+		$$VAL = $$rcvr.lval
 		$$state = $$n
 		if Errflag > 0 {
 			Errflag--
@@ -3540,8 +3537,8 @@ $$default:
 	/* default state action */
 	$$n = $$Def[$$state]
 	if $$n == -2 {
-		if $$char < 0 {
-			$$char, $$token = $$lex1($$lex, &$$lval)
+		if $$rcvr.char < 0 {
+			$$rcvr.char, $$token = $$lex1($$lex, &$$rcvr.lval)
 		}
 
 		/* look through exception table */
@@ -3604,7 +3601,7 @@ $$default:
 			if $$token == $$EofCode {
 				goto ret1
 			}
-			$$char = -1
+			$$rcvr.char = -1
 			$$token = -1
 			goto $$newstate /* try again in the same state */
 		}


### PR DESCRIPTION
Place a fixed size initial stack and the lval inside the parser struct
so that they aren't allocated separately. Place $$char inside the parser
struct to simplify the implementation of Lookahead() and avoid an
allocation of the closure.